### PR TITLE
Fetch member details for selected user instead of command author

### DIFF
--- a/src/commands/user_commands.rs
+++ b/src/commands/user_commands.rs
@@ -14,10 +14,10 @@ pub async fn user(
 
     let guild = ctx.partial_guild().await.unwrap();
 
-    let user_member = match ctx.author_member().await {
-        Some(m) => Ok(m),
-        None => Err("Failed to fetch author as a member"),
-    }?;
+    let user_member = match guild.member(ctx, user.id).await {
+        Ok(member) => member,
+        Err(_) => Err("Failed to fetch the selected user as a member")?,
+    };
 
     let embed = serenity::CreateEmbed::new()
         .title(format!("{0} (`{1}`)", user.name, user.id))


### PR DESCRIPTION
Change:
- Updated the logic to use `guild.member(ctx, user.id)` to fetch the member details of the specified user in the command, rather than using `ctx.author_member()`, which previously fetched the command author's details.

Tested locally and it works fine.